### PR TITLE
Removing trailing slash on void element

### DIFF
--- a/src/wp-includes/robots-template.php
+++ b/src/wp-includes/robots-template.php
@@ -46,7 +46,7 @@ function wp_robots() {
 		return;
 	}
 
-	echo "<meta name='robots' content='" . esc_attr( implode( ', ', $robots_strings ) ) . "' />\n";
+	echo "<meta name='robots' content='" . esc_attr( implode( ', ', $robots_strings ) ) . "'>\n";
 }
 
 /**


### PR DESCRIPTION
Removing trailing slash on void element per W3C Validator.
Trac ticket: https://core.trac.wordpress.org/ticket/59432